### PR TITLE
Fix: Configure uvicorn for Cloud Run deployment

### DIFF
--- a/backend/run_chatbot.py
+++ b/backend/run_chatbot.py
@@ -1,4 +1,6 @@
+import os
 import uvicorn
 
 if __name__ == "__main__":
-    uvicorn.run("src.api:app", host="127.0.0.1", port=8000, reload=True)
+    port = int(os.environ.get("PORT", 8080))
+    uvicorn.run("src.api:app", host="0.0.0.0", port=port, reload=False)


### PR DESCRIPTION
- Change host from 127.0.0.1 to 0.0.0.0 for container accessibility
- Use PORT environment variable (defaults to 8080)
- Disable reload for production deployment