### PR TITLE
Fix Cloud Run startup timeout issues

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -78,8 +78,8 @@ ENV PORT=8080
 # Expose port
 EXPOSE 8080
 
-# Health check
-HEALTHCHECK --interval=30s --timeout=10s --start-period=60s --retries=3 \
+# Health check with extended startup time for model loading
+HEALTHCHECK --interval=30s --timeout=15s --start-period=120s --retries=3 \
     CMD curl -f http://localhost:8080/health || exit 1
 
 # Simple, reliable startup command

--- a/backend/run_chatbot.py
+++ b/backend/run_chatbot.py
@@ -3,4 +3,13 @@ import uvicorn
 
 if __name__ == "__main__":
     port = int(os.environ.get("PORT", 8080))
-    uvicorn.run("core.api:app", host="0.0.0.0", port=port, reload=True)
+    # Production configuration - no reload, proper timeout
+    uvicorn.run(
+        "core.api:app", 
+        host="0.0.0.0", 
+        port=port, 
+        reload=False,  # Disable reload for production
+        workers=1,     # Single worker for Cloud Run
+        timeout_keep_alive=30,
+        access_log=True
+    )

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -32,6 +32,7 @@ steps:
   - '4Gi'
   - '--cpu'
   - '2'
+  - '--cpu-boost'
   - '--min-instances'
   - '1'
   - '--max-instances'
@@ -39,7 +40,7 @@ steps:
   - '--concurrency'
   - '80'
   - '--timeout'
-  - '300'
+  - '900'
   - '--set-env-vars'
   - 'PYTHONPATH=/app/backend,PYTHONDONTWRITEBYTECODE=1'
 


### PR DESCRIPTION
- Fix run_chatbot.py: Remove reload=True, add production config
- Extend Cloud Run timeout from 300s to 900s (15 minutes)
- Add CPU boost for faster startup with BGE model loading
- Extend health check start-period to 120s for model loading
- Configure uvicorn with proper production settings